### PR TITLE
Fix storage initialization on the server

### DIFF
--- a/src/lib/storage.svelte.ts
+++ b/src/lib/storage.svelte.ts
@@ -9,7 +9,7 @@ export class PersistentState<T> {
   #version = $state(0);
   #listeners = 0;
   #value: T | undefined;
-  #storage: Storage;
+  #storage: Storage | undefined;
 
   #handler = (e: StorageEvent) => {
     if (e.storageArea !== this.#storage) return;
@@ -21,7 +21,12 @@ export class PersistentState<T> {
   constructor(key: string, initial?: T, storageType: StorageType = 'localStorage') {
     this.#key = key;
     this.#value = initial;
-    this.#storage = storageType === 'localStorage' ? localStorage : sessionStorage;
+
+    if (storageType === 'localStorage' && typeof localStorage !== 'undefined') {
+      this.#storage = localStorage;
+    } else if (storageType === 'sessionStorage' && typeof sessionStorage !== 'undefined') {
+      this.#storage = sessionStorage;
+    }
 
     if (typeof this.#storage !== 'undefined') {
       if (this.#storage.getItem(key) === null) {


### PR DESCRIPTION
The `localStorage` and `sessionStorage` objects can’t be accessed on the server, throwing an exception when that happens. Accesses need to be within a `typeof storage !== 'undefined'` closure, like the original code:

https://github.com/Rich-Harris/local-storage-test/blob/91472fa04e135a64316db42aae69bec4d6944ca7/src/lib/storage.svelte.ts#L20

This PR only sets `this.#storage` when the object is defined.