### PR TITLE
chore: bump to v0.1.0 with changeset

### DIFF
--- a/.changeset/strict-checks-and-ci.md
+++ b/.changeset/strict-checks-and-ci.md
@@ -1,0 +1,13 @@
+---
+'@friendofsvelte/state': minor
+---
+
+Add strict runtime checks and CI/CD pipeline
+
+- Validate key is non-empty string in constructor
+- Handle corrupted storage data gracefully (falls back to initial value)
+- Handle storage quota exceeded errors without throwing
+- Add 20 comprehensive tests for PersistentState
+- Set up GitHub Actions CI (lint, type-check, test, build)
+- Set up automated releases with Changesets and OIDC trusted publishing
+- Fix dependency vulnerabilities via npm audit fix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@friendofsvelte/state",
 	"description": "Persistent Svelte 5 State, localStorage & sessionStorage",
-	"version": "0.0.6-ts",
+	"version": "0.1.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run prepack",


### PR DESCRIPTION
## Summary
- Bump version from `0.0.6-ts` to `0.1.0` (clean semver)
- Add changeset for the strict checks + CI/CD work merged in PR #3

Once merged, the release workflow will pick up the changeset and publish `@friendofsvelte/state@0.1.0` to npm.

**Prerequisite**: Make sure trusted publisher is configured on npmjs.com before merging (Package Settings > Trusted Publishers > GitHub Actions > `friendofsvelte` / `state` / `release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)