### PR TITLE
fix: release workflow - no PR permissions needed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -29,13 +28,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Create Release PR or Publish
-        uses: changesets/action@v1
-        with:
-          version: npx changeset version
-          publish: npx changeset publish
-          commit: 'chore: version packages'
-          title: 'chore: version packages'
+      - name: Version and publish
+        run: |
+          npx changeset version
+          npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Push version bump
+        run: |
+          git add .
+          git diff --staged --quiet && exit 0
+          git commit -m "chore: version packages"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `changesets/action` PR-based flow with direct version + publish
- Removes `pull-requests: write` permission — fixes the "GitHub Actions is not permitted to create pull requests" error
- On merge to main: versions, publishes to npm, pushes version bump back — all in one step

🤖 Generated with [Claude Code](https://claude.com/claude-code)